### PR TITLE
First try at integrating Fuzz Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+fuzz-*.log
+fuzz/corpus
+fuzz/varint
 coverage
 *.gcov
 out

--- a/fuzz/varint.cpp
+++ b/fuzz/varint.cpp
@@ -1,0 +1,39 @@
+#include <cassert>
+#include <cstdint>
+#include <cctype>
+
+#include <string>
+#include <iterator>
+#include <stdexcept>
+
+#include <protozero/varint.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size) {
+  /* Discard non-integral input */
+
+  if (!std::all_of(data, data + size, ::isdigit))
+    return 0;
+
+  const std::string in(reinterpret_cast<const char *>(data), size);
+
+  /* Swallow exceptions from std::stol(l) in case of overflows */
+
+  /* TODO(daniel-j-h): SFINAE dispatch size for stoi, stol, stoll */
+
+  try {
+    const std::int32_t num32 = stoi(in);
+    assert(protozero::decode_zigzag32(protozero::encode_zigzag32(num32)) == num32);
+  } catch (const std::invalid_argument&) {
+  } catch (const std::out_of_range&) {
+  }
+
+  try {
+    const std::int64_t num64 = stol(in);
+    assert(protozero::decode_zigzag64(protozero::encode_zigzag64(num64)) == num64);
+  } catch (const std::invalid_argument&) {
+  } catch (const std::out_of_range&) {
+  }
+
+  return 0; /* Always return zero, sanitizers hard-abort */
+
+}


### PR DESCRIPTION
This is a first try at Coverage Based Fuzz Testing (plus
Data-flow-guided fuzzing) using LLVM's libFuzzer.

It's building a driver for (at the moment only) the varint zigzag
functions, then compiles it instrumenting the binary with coverage
information. It then spins up the test driver (that gets a main from
libFuzzer), dumping the corpus that changes control-flow into the
fuzz/corpus directory. (This can be kept across runs to speed up fuzzing)

It's best to compile the driver with multiple sanitizers (ubsan, asan,
msan, ..), and fuzz the library with those. Set env var

```
env FUZZ_SANITIZER=
```

for this to e.g. undefined or address or memory, respectively.

Note: -jobs=N can be passed to the driver, letting it fork and run N
jobs in parallel; not doing this at the moment.

I tried this with LLVM 3.8 / libc++ on Linux as it needs a fairly recent
LLVM release; 3.7 should work, too, but I haven't tested this.

Disclaimer: I'm already doing a pull request although it's only fuzzing
the varint zigzag functions to get more traction for fuzzing across
projects.

References:
- http://llvm.org/docs/LibFuzzer.html
- http://llvm.org/releases/3.8.0/docs/LibFuzzer.html
- https://www.youtube.com/watch?v=qTkYDA0En6U
- https://github.com/Project-OSRM/osrm-backend/pull/2251

/cc @TheMarex @joto @artemp @springmeyer @kkaefer @ericfischer

```
env FUZZ_SANITIZER='undefined,integer' CC='clang' CXX='clang++' CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++" make fuzz

./fuzz/varint -use_traces=1 fuzz/corpus
Seed: 1864466908
PreferSmall: 1
0      READ   units: 1 exec/s: 0
1      INITED cov: 32 bits: 32 units: 1 exec/s: 0
2      NEW    cov: 39 bits: 39 indir: 1 units: 2 exec/s: 0 L: 64 MS: 0
112    NEW    cov: 40 bits: 46 indir: 1 units: 3 exec/s: 0 L: 64 MS: 0
559    NEW    cov: 66 bits: 72 indir: 1 units: 4 exec/s: 0 L: 1 MS: 3 EraseByte-CrossOver-EraseByte-
637    NEW    cov: 66 bits: 74 indir: 1 units: 5 exec/s: 0 L: 2 MS: 1 InsertByte-
639    NEW    cov: 66 bits: 79 indir: 1 units: 6 exec/s: 0 L: 3 MS: 3 InsertByte-ShuffleBytes-InsertByte-
642    NEW    cov: 66 bits: 86 indir: 1 units: 7 exec/s: 0 L: 4 MS: 1 CrossOver-
653    NEW    cov: 66 bits: 87 indir: 1 units: 8 exec/s: 0 L: 23 MS: 2 ShuffleBytes-CrossOver-
1364   NEW    cov: 66 bits: 93 indir: 1 units: 9 exec/s: 0 L: 27 MS: 3 CrossOver-CrossOver-CrossOver-
1417   NEW    cov: 66 bits: 94 indir: 1 units: 10 exec/s: 0 L: 31 MS: 1 CrossOver-
3473   NEW    cov: 66 bits: 101 indir: 1 units: 11 exec/s: 0 L: 62 MS: 2 ChangeByte-CrossOver-
4098   NEW    cov: 69 bits: 104 indir: 1 units: 12 exec/s: 0 L: 14 MS: 2 EraseByte-CrossOver-
4602   NEW    cov: 72 bits: 107 indir: 1 units: 13 exec/s: 0 L: 28 MS: 1 CrossOver-
5337   NEW    cov: 72 bits: 114 indir: 1 units: 14 exec/s: 0 L: 44 MS: 1 CrossOver-
2097152        pulse  cov: 72 bits: 114 indir: 1 units: 14 exec/s: 699050
4194304        pulse  cov: 72 bits: 114 indir: 1 units: 14 exec/s: 599186
8388608        pulse  cov: 72 bits: 114 indir: 1 units: 14 exec/s: 599186
```
