### PR TITLE
Pins LLVM 3.8 (stable) instead of tracking the nightly repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons_shortcuts:
       packages: [ 'clang-3.5', 'libprotobuf-dev','protobuf-compiler' ]
   addons_clang38: &clang38
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
       packages: [ 'clang-3.8', 'libprotobuf-dev','protobuf-compiler' ]
   addons_gcc49: &gcc47
     apt:


### PR DESCRIPTION
Clang 3.8 builds are currently failing on Travis, since `llvm-toolchain-precise` only includes Clang 3.9 now (nightly). We need to track `llvm-toolchain-precise-3.8` (stable) for Clang 3.8.

Same as https://github.com/Project-OSRM/osrm-backend/pull/2207.