### PR TITLE
cpp syntax highlighting

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -25,7 +25,9 @@ You need a C++11-capable compiler for protozero to work. Copy the files in the
 `include/protozero` directory somewhere where your build system can find them.
 Keep the `protozero` directory and include the files in the form
 
-    #include <protozero/FILENAME.hpp>
+```cpp
+#include <protozero/FILENAME.hpp>
+```
 
 You always need `byteswap.hpp`, `config.hpp`, `types.hpp`, `varint.hpp`,
 and `exception.hpp`. For reading you need `pbf_reader.hpp` and probably
@@ -40,7 +42,9 @@ defining the library version.
 
 To use the `pbf_reader` class, add this include to your C++ program:
 
-    #include <protozero/pbf_reader.hpp>
+```cpp
+#include <protozero/pbf_reader.hpp>
+```
 
 The `pbf_reader` class contains asserts that will detect some programming
 errors. We encourage you to compile with asserts enabled in your debug builds.
@@ -50,46 +54,49 @@ errors. We encourage you to compile with asserts enabled in your debug builds.
 
 Lets say you have a protocol description in a `.proto` file like this:
 
-    message Example1 {
-        required uint32 x  =  1;
-        optional string s  =  2;
-        repeated fixed64 r = 17;
-    }
+```cpp
+message Example1 {
+    required uint32 x  =  1;
+    optional string s  =  2;
+    repeated fixed64 r = 17;
+}
+```
 
 To read messages created according to that description, you will have code that
 looks somewhat like this:
 
-    #include <protozero/pbf_reader.hpp>
+```cpp
+#include <protozero/pbf_reader.hpp>
 
-    // get data from somewhere into the input string
-    std::string input = get_input_data();
+// get data from somewhere into the input string
+std::string input = get_input_data();
 
-    // initialize pbf message with this data
-    protozero::pbf_reader message(input);
+// initialize pbf message with this data
+protozero::pbf_reader message(input);
 
-    // iterate over fields in the message
-    while (message.next()) {
+// iterate over fields in the message
+while (message.next()) {
 
-        // switch depending on the field tag (the field name is not available)
-        switch (message.tag()) {
-            case 1:
-                // get data for tag 1 (in this case an uint32)
-                auto x = message.get_uint32();
-                break;
-            case 2:
-                // get data for tag 2 (in this case a string)
-                std::string s = message.get_string();
-                break;
-            case 17:
-                // ignore data for tag 17
-                message.skip();
-                break;
-            default:
-                // ignore data for unknown tags to allow for future extensions
-                message.skip();
-        }
-
+    // switch depending on the field tag (the field name is not available)
+    switch (message.tag()) {
+        case 1:
+            // get data for tag 1 (in this case an uint32)
+            auto x = message.get_uint32();
+            break;
+        case 2:
+            // get data for tag 2 (in this case a string)
+            std::string s = message.get_string();
+            break;
+        case 17:
+            // ignore data for tag 17
+            message.skip();
+            break;
+        default:
+            // ignore data for unknown tags to allow for future extensions
+            message.skip();
     }
+}
+```
 
 You always have to call `next()` and then either one of the accessor functions
 (like `get_uint32()` or `get_string()`) to get the field value or `skip()` to
@@ -114,14 +121,15 @@ field.
 If, out of a protocol buffer message, you only need the value of a single
 field, you can use the version of the `next()` function with a parameter:
 
-    // same .proto file and initialization as above
+```cpp
+// same .proto file and initialization as above
 
-    // get all fields with tag 17, skip all others
-    while (message.next(17)) {
-        auto r = message.get_fixed64();
-        std::cout << r << "\n";
-    }
-
+// get all fields with tag 17, skip all others
+while (message.next(17)) {
+    auto r = message.get_fixed64();
+    std::cout << r << "\n";
+}
+```
 
 ### Handling Scalar Fields
 
@@ -146,24 +154,28 @@ are used to access the data.
 So, for example, if you have a protocol description in a `.proto` file like
 this:
 
-    message Example2 {
-        repeated sint32 i = 1 [packed=true];
-    }
+```cpp
+message Example2 {
+    repeated sint32 i = 1 [packed=true];
+}
+```
 
 You can get to the data like this:
 
-    protozero::pbf_reader message(input.data(), input.size());
+```cpp
+protozero::pbf_reader message(input.data(), input.size());
 
-    // set current field
-    item.next(1);
+// set current field
+item.next(1);
 
-    // get an iterator pair
-    auto pi = item.get_packed_sint32();
+// get an iterator pair
+auto pi = item.get_packed_sint32();
 
-    // iterate to get to all values
-    for (auto it = pi.first; it != pi.second; ++it) {
-        std::cout << *it << "\n";
-    }
+// iterate to get to all values
+for (auto it = pi.first; it != pi.second; ++it) {
+    std::cout << *it << "\n";
+}
+```
 
 So you are getting a pair of normal forward iterators that can be used with any
 STL algorithms etc.
@@ -177,37 +189,40 @@ repeated fields are handled in the usual way for scalar fields.
 Protocol Buffers can embed any message inside another message. To access an
 embedded message use the `get_message()` function. So for this description:
 
-    message Point {
-        required double x = 1;
-        required double y = 2;
-    }
+```cpp
+message Point {
+    required double x = 1;
+    required double y = 2;
+}
 
-    message Example3 {
-        repeated Point point = 10;
-    }
+message Example3 {
+    repeated Point point = 10;
+}
+```
 
 you can parse with this code:
 
-    protozero::pbf_reader message(input);
+```cpp
+protozero::pbf_reader message(input);
 
-    while (message.next(10)) {
-        protozero::pbf_reader point = message.get_message();
-        double x, y;
-        while (point.next()) {
-            switch (point.tag()) {
-                case 1:
-                    x = point.get_double();
-                    break;
-                case 2:
-                    y = point.get_double();
-                    break;
-                default:
-                    point.skip();
-            }
+while (message.next(10)) {
+    protozero::pbf_reader point = message.get_message();
+    double x, y;
+    while (point.next()) {
+        switch (point.tag()) {
+            case 1:
+                x = point.get_double();
+                break;
+            case 2:
+                y = point.get_double();
+                break;
+            default:
+                point.skip();
         }
-        std::cout << "x=" << x << " y=" << y << "\n";
     }
-
+    std::cout << "x=" << x << " y=" << y << "\n";
+}
+```
 
 ### Handling Enums
 
@@ -284,19 +299,23 @@ class` and then use the `pbf_message` template class instead of the
 Here is the first example again, this time using this new technique. So you
 have the following in a `.proto` file:
 
-    message Example1 {
-        required uint32 x  =  1;
-        optional string s  =  2;
-        repeated fixed64 r = 17;
-    }
+```cpp
+message Example1 {
+    required uint32 x  =  1;
+    optional string s  =  2;
+    repeated fixed64 r = 17;
+}
+```
 
 Add the following declaration in one of your header files:
 
-    enum class Example1 : protozero::pbf_tag_type {
-        required_uint32_x  =  1,
-        optional_string_s  =  2,
-        repeated_fixed64_r = 17
-    };
+```cpp
+enum class Example1 : protozero::pbf_tag_type {
+    required_uint32_x  =  1,
+    optional_string_s  =  2,
+    repeated_fixed64_r = 17
+};
+```
 
 The message name becomes the name of the `enum class` which is always built
 on top of the `protozero::pbf_tag_type` type. Each field in the message
@@ -309,34 +328,35 @@ To read messages created according to that description, you will have code that
 looks somewhat like this, this time using `pbf_message` instead of
 `pbf_reader`:
 
-    #include <protozero/pbf_message.hpp>
+```cpp
+#include <protozero/pbf_message.hpp>
 
-    // get data from somewhere into the input string
-    std::string input = get_input_data();
+// get data from somewhere into the input string
+std::string input = get_input_data();
 
-    // initialize pbf message with this data
-    protozero::pbf_message<Example1> message(input);
+// initialize pbf message with this data
+protozero::pbf_message<Example1> message(input);
 
-    // iterate over fields in the message
-    while (message.next()) {
+// iterate over fields in the message
+while (message.next()) {
 
-        // switch depending on the field tag (the field name is not available)
-        switch (message.tag()) {
-            case Example1::required_uint32_x:
-                auto x = message.get_uint32();
-                break;
-            case Example1::optional_string_s:
-                std::string s = message.get_string();
-                break;
-            case Example1::repeated_fixed64_r:
-                message.skip();
-                break;
-            default:
-                // ignore data for unknown tags to allow for future extensions
-                message.skip();
-        }
-
+    // switch depending on the field tag (the field name is not available)
+    switch (message.tag()) {
+        case Example1::required_uint32_x:
+            auto x = message.get_uint32();
+            break;
+        case Example1::optional_string_s:
+            std::string s = message.get_string();
+            break;
+        case Example1::repeated_fixed64_r:
+            message.skip();
+            break;
+        default:
+            // ignore data for unknown tags to allow for future extensions
+            message.skip();
     }
+}
+```
 
 Note the correspondance between the enum value (for instance
 `required_uint32_x`) and the name of the getter function (for instance
@@ -365,7 +385,9 @@ data). You can switch of this warning with `-Wno-covered-switch-default`).
 
 To use the `pbf_writer` class, add this include to your C++ program:
 
-    #include <protozero/pbf_writer.hpp>
+```cpp
+#include <protozero/pbf_writer.hpp>
+```
 
 The `pbf_writer` class contains asserts that will detect some programming
 errors. We encourage you to compile with asserts enabled in your debug builds.
@@ -375,25 +397,29 @@ errors. We encourage you to compile with asserts enabled in your debug builds.
 
 Lets say you have a protocol description in a `.proto` file like this:
 
-    message Example {
-        required uint32 x = 1;
-        optional string s = 2;
-        repeated fixed64 r = 17;
-    }
+```cpp
+message Example {
+    required uint32 x = 1;
+    optional string s = 2;
+    repeated fixed64 r = 17;
+}
+```
 
 To write messages created according to that description, you will have code
 that looks somewhat like this:
 
-    #include <protozero/pbf_writer.hpp>
+```cpp
+#include <protozero/pbf_writer.hpp>
 
-    std::string data;
-    protozero::pbf_writer pbf_example(data);
+std::string data;
+protozero::pbf_writer pbf_example(data);
 
-    pbf_example.add_uint32(1, 27);       // uint32_t x
-    pbf_example.add_fixed64(17, 1);      // fixed64 r
-    pbf_example.add_fixed64(17, 2);
-    pbf_example.add_fixed64(17, 3);
-    pbf_example.add_string(2, "foobar"); // string s
+pbf_example.add_uint32(1, 27);       // uint32_t x
+pbf_example.add_fixed64(17, 1);      // fixed64 r
+pbf_example.add_fixed64(17, 2);
+pbf_example.add_fixed64(17, 3);
+pbf_example.add_string(2, "foobar"); // string s
+```
 
 First you need a string which will be used as buffer to assemble the
 protobuf-formatted message. The `pbf_writer` object contains a reference to
@@ -423,22 +449,26 @@ the `.proto` file are not available.
 
 Repeated packed fields can easily be set from a pair of iterators:
 
-    std::string data;
-    protozero::pbf_writer pw(data);
+```cpp
+std::string data;
+protozero::pbf_writer pw(data);
 
-    std::vector<int> v = { 1, 4, 9, 16, 25, 36 };
-    pw.add_packed_int32(1, std::begin(v), std::end(v));
+std::vector<int> v = { 1, 4, 9, 16, 25, 36 };
+pw.add_packed_int32(1, std::begin(v), std::end(v));
+```
 
 If you don't have an iterator you can use the alternative form:
 
-    std::string data;
-    protozero::pbf_writer pw(data);
-    {
-        protozero::packed_field_int32 field{pw, 1};
-        field.add_element(1);
-        field.add_element(10);
-        field.add_element(100);
-    }
+```cpp
+std::string data;
+protozero::pbf_writer pw(data);
+{
+    protozero::packed_field_int32 field{pw, 1};
+    field.add_element(1);
+    field.add_element(10);
+    field.add_element(100);
+}
+```
 
 Of course you can add as many elements as you want. If you add no elements
 at all, this code will still work, protozero detects this special case and
@@ -452,13 +482,15 @@ the right value. You must close that scope before adding other fields to the
 If you know how many elements you will add to the field and your field contains
 fixed length elements, you can tell Protozero and it can optimize this case:
 
-    std::string data;
-    protozero::pbf_writer pw(data);
-    {
-        protozero::packed_field_fixed32 field{pw, 1, 2}; // exactly two elements
-        field.add_element(42);
-        field.add_element(13);
-    }
+```cpp
+std::string data;
+protozero::pbf_writer pw(data);
+{
+    protozero::packed_field_fixed32 field{pw, 1, 2}; // exactly two elements
+    field.add_element(42);
+    field.add_element(13);
+}
+```
 
 In this case you have to supply exactly as many elements as you promised,
 otherwise you will get a broken protobuf message.
@@ -470,14 +502,16 @@ This works for `packed_field_fixed32`, `packed_field_sfixed32`,
 You can abandon writing of the packed field if this becomes necessary by
 calling `rollback()`:
 
-    std::string data;
-    protozero::pbf_writer pw(data);
-    {
-        protozero::packed_field_int32 field{pw, 1};
-        field.add_element(42);
-        // some error occurs, you don't want to have this field at all
-        field.rollback();
-    }
+```cpp
+std::string data;
+protozero::pbf_writer pw(data);
+{
+    protozero::packed_field_int32 field{pw, 1};
+    field.add_element(42);
+    // some error occurs, you don't want to have this field at all
+    field.rollback();
+}
+```
 
 The result is the same as if the lines inside the nested brackets had never
 been called. Do not try to call `add_element()` after a rollback.
@@ -488,42 +522,46 @@ been called. Do not try to call `add_element()` after a rollback.
 Nested sub-messages can be handled by first creating the submessage and then
 adding to the parent message:
 
-    std::string buffer_sub;
-    protozero::pbf_writer pbf_sub(buffer_sub);
+```cpp
+std::string buffer_sub;
+protozero::pbf_writer pbf_sub(buffer_sub);
 
-    // add fields to sub-message
-    pbf_sub.add_...(...);
-    // ...
+// add fields to sub-message
+pbf_sub.add_...(...);
+// ...
 
-    // sub-message is finished here
+// sub-message is finished here
 
-    std::string buffer_parent;
-    protozero::pbf_writer pbf_parent(buffer_parent);
-    pbf_parent.add_message(1, buffer_sub);
+std::string buffer_parent;
+protozero::pbf_writer pbf_parent(buffer_parent);
+pbf_parent.add_message(1, buffer_sub);
+```
 
 This is easy to do but it has the drawback of needing a separate `std::string`
 buffer. If this concerns you (and why would you use protozero and not the
 Google protobuf library if it doesn't?) there is another way:
 
-    std::string data;
-    protozero::pbf_writer pbf_parent(data);
+```cpp
+std::string data;
+protozero::pbf_writer pbf_parent(data);
 
-    // optionally add fields to parent here
-    pbf_parent.add_...(...);
+// optionally add fields to parent here
+pbf_parent.add_...(...);
 
-    // open a new scope
-    {
-        // create new pbf_writer with parent and the tag (field number)
-        // as parameters
-        protozero::pbf_writer pbf_sub(pbf_parent, 1);
+// open a new scope
+{
+    // create new pbf_writer with parent and the tag (field number)
+    // as parameters
+    protozero::pbf_writer pbf_sub(pbf_parent, 1);
 
-        // add fields to sub here...
-        pbf_sub.add_...(...);
+    // add fields to sub here...
+    pbf_sub.add_...(...);
 
-    } // closing the scope will close the sub-message
+} // closing the scope will close the sub-message
 
-    // optionally add more fields to parent here
-    pbf_parent.add_...(...);
+// optionally add more fields to parent here
+pbf_parent.add_...(...);
+```
 
 This can be nested arbitrarily deep.
 
@@ -537,24 +575,26 @@ than was available, the rest of the buffer is moved over a few bytes.
 You can abandon writing of submessage if this becomes necessary by
 calling `rollback()`:
 
-    std::string data;
-    protozero::pbf_writer pbf_parent(data);
+```cpp
+std::string data;
+protozero::pbf_writer pbf_parent(data);
 
-    // open a new scope
-    {
-        // create new pbf_writer with parent and the tag (field number)
-        // as parameters
-        protozero::pbf_writer pbf_sub(pbf_parent, 1);
+// open a new scope
+{
+    // create new pbf_writer with parent and the tag (field number)
+    // as parameters
+    protozero::pbf_writer pbf_sub(pbf_parent, 1);
 
-        // add fields to sub here...
-        pbf_sub.add_...(...);
+    // add fields to sub here...
+    pbf_sub.add_...(...);
 
-        // some problem occurs and you want to abandon the submessage:
-        pbf_sub.rollback();
-    }
+    // some problem occurs and you want to abandon the submessage:
+    pbf_sub.rollback();
+}
 
-    // optionally add more fields to parent here
-    pbf_parent.add_...(...);
+// optionally add more fields to parent here
+pbf_parent.add_...(...);
+```
 
 The result is the same as if the lines inside the nested brackets had never
 been called. Do not try to call any of the `add_*` functions on the submessage
@@ -601,12 +641,14 @@ To use the low-level, add this include to your C++ program:
 
 The following functions are then available:
 
-    decode_varint()
-    write_varint()
-    encode_zigzag32()
-    encode_zigzag64()
-    decode_zigzag32()
-    decode_zigzag64()
+```cpp
+decode_varint()
+write_varint()
+encode_zigzag32()
+encode_zigzag64()
+decode_zigzag32()
+decode_zigzag64()
+```
 
 See the reference documentation created by `make doc` for details.
 


### PR DESCRIPTION
Updates markdown code snippets to be `cpp` highlighted. 

Refs: #61 

cc @joto @flippmoke @springmeyer @daniel-j-h  