### PR TITLE
Fixes Undefined Behavior due to Type Punning, resolves #64

### DIFF
--- a/include/protozero/byteswap.hpp
+++ b/include/protozero/byteswap.hpp
@@ -16,6 +16,7 @@ documentation.
  * @brief Contains functions to swap bytes in values (for different endianness).
  */
 
+#include <cstring>
 #include <cstdint>
 #include <cassert>
 
@@ -38,7 +39,10 @@ inline void byteswap(const char* /*data*/, char* /*result*/) noexcept {
 template <>
 inline void byteswap<4>(const char* data, char* result) noexcept {
 #ifdef PROTOZERO_USE_BUILTIN_BSWAP
-    *reinterpret_cast<uint32_t*>(result) = __builtin_bswap32(*reinterpret_cast<const uint32_t*>(data));
+    uint32_t tmp;
+    std::memcpy(&tmp, data, sizeof(tmp));
+    const uint32_t swapped = __builtin_bswap32(tmp);
+    std::memcpy(result, &swapped, sizeof(swapped));
 #else
     result[3] = data[0];
     result[2] = data[1];
@@ -53,7 +57,10 @@ inline void byteswap<4>(const char* data, char* result) noexcept {
 template <>
 inline void byteswap<8>(const char* data, char* result) noexcept {
 #ifdef PROTOZERO_USE_BUILTIN_BSWAP
-    *reinterpret_cast<uint64_t*>(result) = __builtin_bswap64(*reinterpret_cast<const uint64_t*>(data));
+    uint64_t tmp;
+    std::memcpy(&tmp, data, sizeof(tmp));
+    const uint64_t swapped = __builtin_bswap64(tmp);
+    std::memcpy(result, &swapped, sizeof(swapped));
 #else
     result[7] = data[0];
     result[6] = data[1];


### PR DESCRIPTION
The `byteswap` functions cast a `char *`  (alignment requirement of 1)
to a `uint32_t* ` / `uint64_t *` (higher alignment requirement).

This is Undefined Behavior.

It could e.g. fail on platforms other than x86 or if you enable
SSE and the compiler wants to make use of alignment guarantees.

The only way to mitigate this is to do a `bit_cast`-ish `memcpy`:

- http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0476r0.html
- https://github.com/jfbastien/bit_cast

The compilers are smart enough to look through all of this and will
gratefully generate a `bswap` inst. in these specific setting:

- Clang https://godbolt.org/g/NVDL31
- GCC https://godbolt.org/g/fnRheQ

Codegen for fixed version:

```asm
byteswap32builtin(char const*, char*):
        movl    (%rdi), %eax
        bswap   %eax
        movl    %eax, (%rsi)
        ret
```