### PR TITLE
Move coverage reporting to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,15 +91,8 @@ matrix:
 
 before_install:
  - echo ${CXX}
- - if [[ $(uname -s) == 'Linux' ]]; then
-     export PYTHONPATH=$(pwd)/.local/lib/python2.7/site-packages;
-   else
+ - if [[ $(uname -s) == 'Darwin' ]]; then
      brew install protobuf;
-     export PYTHONPATH=$(pwd)/.local/lib/python/site-packages;
-   fi
- - if [ -n "${COVERAGE}" ]; then
-     PYTHONUSERBASE=$(pwd)/.local pip install --user urllib3[secure];
-     PYTHONUSERBASE=$(pwd)/.local pip install --user cpp-coveralls;
    fi
 
 install:
@@ -107,9 +100,13 @@ install:
  - if [ -n "${BUILD_DOC}" ]; then make doc; fi
 
 script:
- - if [ -n "${COVERAGE}" ]; then
-    make clean;
-    CXXFLAGS="--coverage ${CXXFLAGS}" LDFLAGS="--coverage ${LDFLAGS}" make test;
-    ${COVERAGE} -lp test/*tests.o test/t/*/*test_cases.o;
-    ./.local/bin/cpp-coveralls --no-gcov -i include/protozero;
-   fi
+  - |
+    if [ -n "${COVERAGE}" ]; then
+      make clean
+      CXXFLAGS="--coverage ${CXXFLAGS}" LDFLAGS="--coverage ${LDFLAGS}" make test
+      which ${COVERAGE}
+      curl -S -f https://codecov.io/bash -o codecov
+      chmod +x codecov
+      ${COVERAGE} -p $(find test/ -name '*.o')
+      ./codecov -Z -f '*protozero*' -X search
+    fi

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the Google Protobufs `protoc` program.
 
 [![Travis Build Status](https://travis-ci.org/mapbox/protozero.svg?branch=master)](https://travis-ci.org/mapbox/protozero)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/o354pq10y96mnr6d?svg=true)](https://ci.appveyor.com/project/Mapbox/protozero)
-[![Coverage Status](https://coveralls.io/repos/mapbox/protozero/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/protozero?branch=master)
+[![Coverage Status](https://codecov.io/gh/mapbox/protozero/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/protozero)
 
 ## Depends
 


### PR DESCRIPTION
This drops coveralls.io and moves to codecov.io, dodging #68.