### PR TITLE
const_fixed_iterator to a Random access iterator

### DIFF
--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -164,14 +164,15 @@ class const_fixed_iterator {
 
 public:
 
-    using iterator_category = std::forward_iterator_tag;
+    //using iterator_category = std::forward_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
     using value_type        = T;
     using difference_type   = std::ptrdiff_t;
     using pointer           = value_type*;
     using reference         = value_type&;
 
     static std::size_t range_size(const const_fixed_iterator& begin, const const_fixed_iterator& end) noexcept {
-        return static_cast<std::size_t>(end.m_data - begin.m_data) / sizeof(T);
+        return static_cast<std::size_t>(std::distance(begin, end));
     }
 
     const_fixed_iterator() noexcept = default;
@@ -216,7 +217,72 @@ public:
         return !(*this == rhs);
     }
 
+    const_fixed_iterator& operator--() {
+        m_data -= sizeof(value_type);
+        return *this;
+    }
+
+    const_fixed_iterator operator--(int) {
+        const const_fixed_iterator tmp{*this};
+        --(*this);
+        return tmp;
+    }
+    
+    friend bool operator<(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+        return (lhs.m_data - rhs.m_data) > 0;
+    }
+
+    friend bool operator>(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+        return rhs < lhs;
+    }
+
+    friend bool operator<=(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+        return !(lhs > rhs);
+    }
+
+    friend bool operator>=(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+        return !(lhs < rhs);
+
+    }
+
+    const_fixed_iterator& operator+=(difference_type val) {
+        m_data += (sizeof(value_type) * val);
+        return *this;
+    }
+
+    friend const_fixed_iterator operator+(const const_fixed_iterator& lhs, difference_type rhs) {
+        const_fixed_iterator tmp{lhs};
+        tmp.m_data += (sizeof(value_type) * rhs);
+        return tmp;
+    }
+
+    friend const_fixed_iterator operator+(difference_type lhs, const const_fixed_iterator& rhs) {
+        const_fixed_iterator tmp{rhs};
+        tmp.m_data += (sizeof(value_type) * lhs);
+        return tmp;
+    }
+
+    const_fixed_iterator& operator-=(difference_type val) {
+        m_data -= (sizeof(value_type) * val);
+        return *this;
+    }
+
+    friend const_fixed_iterator operator-(const const_fixed_iterator& lhs, difference_type rhs) {
+        const_fixed_iterator tmp{lhs};
+        tmp.m_data += (sizeof(value_type) * rhs);
+        return tmp;
+    }
+
+    friend difference_type operator-(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+        return static_cast<difference_type>(lhs.m_data - rhs.m_data) / sizeof(T);
+    }
+
+    reference operator[](difference_type n) const {
+        return *(*this + n);
+    }
+
 }; // class const_fixed_iterator
+
 
 /**
  * A forward iterator used for accessing packed repeated varint fields

--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -229,7 +229,7 @@ public:
     }
     
     friend bool operator<(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
-        return (lhs.m_data - rhs.m_data) > 0;
+        return (rhs.m_data - lhs.m_data) > 0;
     }
 
     friend bool operator>(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
@@ -269,12 +269,12 @@ public:
 
     friend const_fixed_iterator operator-(const const_fixed_iterator& lhs, difference_type rhs) {
         const_fixed_iterator tmp{lhs};
-        tmp.m_data += (sizeof(value_type) * rhs);
+        tmp.m_data -= (sizeof(value_type) * rhs);
         return tmp;
     }
 
     friend difference_type operator-(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
-        return static_cast<difference_type>(lhs.m_data - rhs.m_data) / sizeof(T);
+        return static_cast<difference_type>(lhs.m_data - rhs.m_data) / static_cast<difference_type>(sizeof(T));
     }
 
     reference operator[](difference_type n) const {

--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -164,7 +164,6 @@ class const_fixed_iterator {
 
 public:
 
-    //using iterator_category = std::forward_iterator_tag;
     using iterator_category = std::random_access_iterator_tag;
     using value_type        = T;
     using difference_type   = std::ptrdiff_t;
@@ -198,12 +197,12 @@ public:
         return result;
     }
 
-    const_fixed_iterator& operator++() {
+    const_fixed_iterator& operator++() noexcept {
         m_data += sizeof(value_type);
         return *this;
     }
 
-    const_fixed_iterator operator++(int) {
+    const_fixed_iterator operator++(int) noexcept {
         const const_fixed_iterator tmp{*this};
         ++(*this);
         return tmp;
@@ -217,67 +216,67 @@ public:
         return !(*this == rhs);
     }
 
-    const_fixed_iterator& operator--() {
+    const_fixed_iterator& operator--() noexcept {
         m_data -= sizeof(value_type);
         return *this;
     }
 
-    const_fixed_iterator operator--(int) {
+    const_fixed_iterator operator--(int) noexcept {
         const const_fixed_iterator tmp{*this};
         --(*this);
         return tmp;
     }
     
-    friend bool operator<(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
-        return (rhs.m_data - lhs.m_data) > 0;
+    friend bool operator<(const const_fixed_iterator lhs, const const_fixed_iterator rhs) noexcept {
+        return lhs.m_data < rhs.m_data;
     }
 
-    friend bool operator>(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+    friend bool operator>(const const_fixed_iterator lhs, const const_fixed_iterator rhs) noexcept {
         return rhs < lhs;
     }
 
-    friend bool operator<=(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+    friend bool operator<=(const const_fixed_iterator lhs, const const_fixed_iterator rhs) noexcept {
         return !(lhs > rhs);
     }
 
-    friend bool operator>=(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+    friend bool operator>=(const const_fixed_iterator lhs, const const_fixed_iterator rhs) noexcept {
         return !(lhs < rhs);
 
     }
 
-    const_fixed_iterator& operator+=(difference_type val) {
+    const_fixed_iterator& operator+=(difference_type val) noexcept {
         m_data += (sizeof(value_type) * val);
         return *this;
     }
 
-    friend const_fixed_iterator operator+(const const_fixed_iterator& lhs, difference_type rhs) {
+    friend const_fixed_iterator operator+(const const_fixed_iterator lhs, difference_type rhs) noexcept {
         const_fixed_iterator tmp{lhs};
         tmp.m_data += (sizeof(value_type) * rhs);
         return tmp;
     }
 
-    friend const_fixed_iterator operator+(difference_type lhs, const const_fixed_iterator& rhs) {
+    friend const_fixed_iterator operator+(difference_type lhs, const const_fixed_iterator rhs) noexcept {
         const_fixed_iterator tmp{rhs};
         tmp.m_data += (sizeof(value_type) * lhs);
         return tmp;
     }
 
-    const_fixed_iterator& operator-=(difference_type val) {
+    const_fixed_iterator& operator-=(difference_type val) noexcept {
         m_data -= (sizeof(value_type) * val);
         return *this;
     }
 
-    friend const_fixed_iterator operator-(const const_fixed_iterator& lhs, difference_type rhs) {
+    friend const_fixed_iterator operator-(const const_fixed_iterator lhs, difference_type rhs) noexcept {
         const_fixed_iterator tmp{lhs};
         tmp.m_data -= (sizeof(value_type) * rhs);
         return tmp;
     }
 
-    friend difference_type operator-(const const_fixed_iterator& lhs, const const_fixed_iterator& rhs) {
+    friend difference_type operator-(const const_fixed_iterator lhs, const const_fixed_iterator rhs) noexcept {
         return static_cast<difference_type>(lhs.m_data - rhs.m_data) / static_cast<difference_type>(sizeof(T));
     }
 
-    reference operator[](difference_type n) const {
+    value_type operator[](difference_type n) const noexcept {
         return *(*this + n);
     }
 

--- a/test/t/repeated_packed_double/reader_test_cases.cpp
+++ b/test/t/repeated_packed_double/reader_test_cases.cpp
@@ -63,6 +63,13 @@ TEST_CASE("read repeated packed double field") {
             REQUIRE(*it4 == 1.0);
             it4 -= 2;
             REQUIRE(*it4 == 17.34);
+            it4 += 2;
+            REQUIRE(*it4 == 1.0);
+            REQUIRE(*it4-- == 1.0);
+            REQUIRE(*it4 == 0.0);
+            REQUIRE(*--it4 == 17.34);
+            REQUIRE(it4[0] == 17.34);
+            REQUIRE(it4[1] == 0.0);
             REQUIRE(std::distance(it_range.begin(), it_range.end()) == 5);
             REQUIRE(it_range.end() - it_range.begin() == 5);
             REQUIRE(it_range.begin() - it_range.end() == -5);

--- a/test/t/repeated_packed_double/reader_test_cases.cpp
+++ b/test/t/repeated_packed_double/reader_test_cases.cpp
@@ -47,6 +47,26 @@ TEST_CASE("read repeated packed double field") {
             REQUIRE(*it++ == std::numeric_limits<double>::min());
             REQUIRE(*it++ == std::numeric_limits<double>::max());
             REQUIRE(it == it_range.end());
+
+            it = it_range.begin();
+            auto it2 = it + 1;
+            REQUIRE(it2 > it);
+            REQUIRE(it < it2);
+            REQUIRE(it <= it_range.begin());
+            REQUIRE(it >= it_range.begin());
+            REQUIRE(*it2 == 0.0);
+            auto it3 = 1 + it;
+            REQUIRE(*it3 == 0.0);
+            auto it4 = it2 - 1;
+            REQUIRE(*it4 == 17.34);
+            it4 += 2;
+            REQUIRE(*it4 == 1.0);
+            it4 -= 2;
+            REQUIRE(*it4 == 17.34);
+            REQUIRE(std::distance(it_range.begin(), it_range.end()) == 5);
+            REQUIRE(it_range.end() - it_range.begin() == 5);
+            REQUIRE(it_range.begin() - it_range.end() == -5);
+
         }
 
         SECTION("end_of_buffer") {


### PR DESCRIPTION
I wanted to enable the ability for `std::distance()` to work properly with our iterators and that drove me to make `const_fixed_iterator` a random access iterator. However, this still does not solve the problem for `const_varint_iterator`. 