### PR TITLE
Make std::distance work with protozero iterators

### DIFF
--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -245,8 +245,7 @@ for (auto value : range) {
 It depends on the type of range how expensive the `size()` call is. For ranges
 derived from packed repeated fixed sized values the effort will be constant,
 for ranges derived from packed repeated varints, the effort will be linear, but
-still considerably cheaper than decoding the varints (for instance by calling
-`std::distance(range.begin(), range.end());`). You have to benchmark your use
-case to see whether the `reserve()` (or whatever you are using the `size()`
-for) is worth it.
+still considerably cheaper than decoding the varints. You have to benchmark
+your use case to see whether the `reserve()` (or whatever you are using the
+`size()` for) is worth it.
 

--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -410,42 +410,42 @@ namespace std {
 
     template <>
     inline typename protozero::const_varint_iterator<int32_t>::difference_type
-    distance<protozero::const_varint_iterator<int32_t>>(protozero::const_varint_iterator<int32_t> first,
+    distance<protozero::const_varint_iterator<int32_t>>(protozero::const_varint_iterator<int32_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                         protozero::const_varint_iterator<int32_t> last) {
         return protozero::const_varint_iterator<int32_t>::distance(first, last);
     }
 
     template <>
     inline typename protozero::const_varint_iterator<int64_t>::difference_type
-    distance<protozero::const_varint_iterator<int64_t>>(protozero::const_varint_iterator<int64_t> first,
+    distance<protozero::const_varint_iterator<int64_t>>(protozero::const_varint_iterator<int64_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                         protozero::const_varint_iterator<int64_t> last) {
         return protozero::const_varint_iterator<int64_t>::distance(first, last);
     }
 
     template <>
     inline typename protozero::const_varint_iterator<uint32_t>::difference_type
-    distance<protozero::const_varint_iterator<uint32_t>>(protozero::const_varint_iterator<uint32_t> first,
+    distance<protozero::const_varint_iterator<uint32_t>>(protozero::const_varint_iterator<uint32_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                          protozero::const_varint_iterator<uint32_t> last) {
         return protozero::const_varint_iterator<uint32_t>::distance(first, last);
     }
 
     template <>
     inline typename protozero::const_varint_iterator<uint64_t>::difference_type
-    distance<protozero::const_varint_iterator<uint64_t>>(protozero::const_varint_iterator<uint64_t> first,
+    distance<protozero::const_varint_iterator<uint64_t>>(protozero::const_varint_iterator<uint64_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                          protozero::const_varint_iterator<uint64_t> last) {
         return protozero::const_varint_iterator<uint64_t>::distance(first, last);
     }
 
     template <>
     inline typename protozero::const_svarint_iterator<int32_t>::difference_type
-    distance<protozero::const_svarint_iterator<int32_t>>(protozero::const_svarint_iterator<int32_t> first,
+    distance<protozero::const_svarint_iterator<int32_t>>(protozero::const_svarint_iterator<int32_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                          protozero::const_svarint_iterator<int32_t> last) {
         return protozero::const_svarint_iterator<int32_t>::distance(first, last);
     }
 
     template <>
     inline typename protozero::const_svarint_iterator<int64_t>::difference_type
-    distance<protozero::const_svarint_iterator<int64_t>>(protozero::const_svarint_iterator<int64_t> first,
+    distance<protozero::const_svarint_iterator<int64_t>>(protozero::const_svarint_iterator<int64_t> first, // NOLINT clang-tidy: readability-inconsistent-declaration-parameter-name
                                                          protozero::const_svarint_iterator<int64_t> last) {
         return protozero::const_svarint_iterator<int64_t>::distance(first, last);
     }

--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -105,7 +105,7 @@ public:
      * Complexity: Constant or linear depending on the underlaying iterator.
      */
     std::size_t size() const noexcept {
-        return T::range_size(begin(), end());
+        return static_cast<size_t>(std::distance(begin(), end()));
     }
 
     /**
@@ -169,10 +169,6 @@ public:
     using difference_type   = std::ptrdiff_t;
     using pointer           = value_type*;
     using reference         = value_type&;
-
-    static std::size_t range_size(const_fixed_iterator begin, const_fixed_iterator end) noexcept {
-        return static_cast<std::size_t>(std::distance(begin, end));
-    }
 
     const_fixed_iterator() noexcept = default;
 
@@ -282,7 +278,6 @@ public:
 
 }; // class const_fixed_iterator
 
-
 /**
  * A forward iterator used for accessing packed repeated varint fields
  * (int32, uint32, int64, uint64, bool, enum).
@@ -306,13 +301,13 @@ public:
     using pointer           = value_type*;
     using reference         = value_type&;
 
-    static std::size_t range_size(const const_varint_iterator& begin, const const_varint_iterator& end) noexcept {
+    static difference_type distance(const_varint_iterator begin, const_varint_iterator end) noexcept {
         // We know that each varint contains exactly one byte with the most
         // significant bit not set. We can use this to quickly figure out
         // how many varints there are without actually decoding the varints.
-        return static_cast<std::size_t>(std::count_if(begin.m_data, end.m_data, [](char c) noexcept {
+        return std::count_if(begin.m_data, end.m_data, [](char c) noexcept {
             return (static_cast<unsigned char>(c) & 0x80) == 0;
-        }));
+        });
     }
 
     const_varint_iterator() noexcept = default;
@@ -406,5 +401,55 @@ public:
 }; // class const_svarint_iterator
 
 } // end namespace protozero
+
+namespace std {
+
+    // Specialize std::distance for all the protozero iterators. Because
+    // functions can't be partially specialized, we have to do this for
+    // every value_type we are using.
+
+    template <>
+    inline typename protozero::const_varint_iterator<int32_t>::difference_type
+    distance<protozero::const_varint_iterator<int32_t>>(protozero::const_varint_iterator<int32_t> first,
+                                                        protozero::const_varint_iterator<int32_t> last) {
+        return protozero::const_varint_iterator<int32_t>::distance(first, last);
+    }
+
+    template <>
+    inline typename protozero::const_varint_iterator<int64_t>::difference_type
+    distance<protozero::const_varint_iterator<int64_t>>(protozero::const_varint_iterator<int64_t> first,
+                                                        protozero::const_varint_iterator<int64_t> last) {
+        return protozero::const_varint_iterator<int64_t>::distance(first, last);
+    }
+
+    template <>
+    inline typename protozero::const_varint_iterator<uint32_t>::difference_type
+    distance<protozero::const_varint_iterator<uint32_t>>(protozero::const_varint_iterator<uint32_t> first,
+                                                         protozero::const_varint_iterator<uint32_t> last) {
+        return protozero::const_varint_iterator<uint32_t>::distance(first, last);
+    }
+
+    template <>
+    inline typename protozero::const_varint_iterator<uint64_t>::difference_type
+    distance<protozero::const_varint_iterator<uint64_t>>(protozero::const_varint_iterator<uint64_t> first,
+                                                         protozero::const_varint_iterator<uint64_t> last) {
+        return protozero::const_varint_iterator<uint64_t>::distance(first, last);
+    }
+
+    template <>
+    inline typename protozero::const_svarint_iterator<int32_t>::difference_type
+    distance<protozero::const_svarint_iterator<int32_t>>(protozero::const_svarint_iterator<int32_t> first,
+                                                         protozero::const_svarint_iterator<int32_t> last) {
+        return protozero::const_svarint_iterator<int32_t>::distance(first, last);
+    }
+
+    template <>
+    inline typename protozero::const_svarint_iterator<int64_t>::difference_type
+    distance<protozero::const_svarint_iterator<int64_t>>(protozero::const_svarint_iterator<int64_t> first,
+                                                         protozero::const_svarint_iterator<int64_t> last) {
+        return protozero::const_svarint_iterator<int64_t>::distance(first, last);
+    }
+
+} // end namespace std
 
 #endif // PROTOZERO_ITERATORS_HPP

--- a/test/include/packed_access.hpp
+++ b/test/include/packed_access.hpp
@@ -281,11 +281,13 @@ TEST_CASE("write from different types of iterators: " PBF_TYPE_NAME) {
 
     REQUIRE(it_range.front() ==  1); it_range.drop_front();
     REQUIRE(it_range.front() ==  4); it_range.drop_front();
+    REQUIRE(std::distance(it_range.begin(), it_range.end()) == 3);
     REQUIRE(it_range.size() == 3);
     REQUIRE(it_range.front() ==  9); it_range.drop_front();
     REQUIRE(it_range.front() == 16); it_range.drop_front();
     REQUIRE(it_range.front() == 25); it_range.drop_front();
     REQUIRE(it_range.empty());
+    REQUIRE(std::distance(it_range.begin(), it_range.end()) == 0);
     REQUIRE(it_range.size() == 0); // NOLINT clang-tidy: readability-container-size-empty
 
     REQUIRE_THROWS_AS(it_range.front(), const assert_error&);

--- a/test/t/repeated_packed_bool/reader_test_cases.cpp
+++ b/test/t/repeated_packed_bool/reader_test_cases.cpp
@@ -16,6 +16,7 @@ TEST_CASE("read repeated packed bool field: one") {
 
     REQUIRE(item.next());
     const auto it_range = item.get_packed_bool();
+    REQUIRE(std::distance(it_range.begin(), it_range.end()) == 1);
     REQUIRE(it_range.size() == 1);
     REQUIRE_FALSE(item.next());
 
@@ -31,6 +32,7 @@ TEST_CASE("read repeated packed bool field: many") {
 
     REQUIRE(item.next());
     const auto it_range = item.get_packed_bool();
+    REQUIRE(std::distance(it_range.begin(), it_range.end()) == 4);
     REQUIRE(it_range.size() == 4);
     REQUIRE_FALSE(item.next());
 


### PR DESCRIPTION
This specializes `std::distance` for our iterators.

See #86.

@flippmoke ?