### PR TITLE
Specify proto2 syntax to appease protoc

### DIFF
--- a/test/t/bool/bool_testcase.proto
+++ b/test/t/bool/bool_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/bytes/bytes_testcase.proto
+++ b/test/t/bytes/bytes_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/complex/testcase.proto
+++ b/test/t/complex/testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/double/double_testcase.proto
+++ b/test/t/double/double_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/enum/enum_testcase.proto
+++ b/test/t/enum/enum_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/fixed32/fixed32_testcase.proto
+++ b/test/t/fixed32/fixed32_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/fixed64/testcase.proto
+++ b/test/t/fixed64/testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/float/testcase.proto
+++ b/test/t/float/testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/int32/int32_testcase.proto
+++ b/test/t/int32/int32_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/int64/testcase.proto
+++ b/test/t/int64/testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/message/message_testcase.proto
+++ b/test/t/message/message_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/nested/nested_testcase.proto
+++ b/test/t/nested/nested_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/repeated/repeated_testcase.proto
+++ b/test/t/repeated/repeated_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/repeated_packed_fixed32/repeated_packed_fixed32_testcase.proto
+++ b/test/t/repeated_packed_fixed32/repeated_packed_fixed32_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 

--- a/test/t/string/string_testcase.proto
+++ b/test/t/string/string_testcase.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 
 option optimize_for = LITE_RUNTIME;
 


### PR DESCRIPTION
Warnings seen for Ubuntu 18.04:

```
...
[ 52%] Generating t/string/string_testcase.pb.cc, t/string/string_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: string_testcase.proto. Please use 'syntax = "proto2"
;' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 53%] Generating t/bool/bool_testcase.pb.cc, t/bool/bool_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: bool_testcase.proto. Please use 'syntax = "proto2";'
 or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 54%] Generating t/bytes/bytes_testcase.pb.cc, t/bytes/bytes_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: bytes_testcase.proto. Please use 'syntax = "proto2";
' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 55%] Generating t/double/double_testcase.pb.cc, t/double/double_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: double_testcase.proto. Please use 'syntax = "proto2"
;' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 56%] Generating t/enum/enum_testcase.pb.cc, t/enum/enum_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: enum_testcase.proto. Please use 'syntax = "proto2";'
 or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 57%] Generating t/fixed32/fixed32_testcase.pb.cc, t/fixed32/fixed32_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: fixed32_testcase.proto. Please use 'syntax = "proto2
";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 58%] Generating t/int32/int32_testcase.pb.cc, t/int32/int32_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: int32_testcase.proto. Please use 'syntax = "proto2";
' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 60%] Generating t/message/message_testcase.pb.cc, t/message/message_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: message_testcase.proto. Please use 'syntax = "proto2
";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 61%] Generating t/nested/nested_testcase.pb.cc, t/nested/nested_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: nested_testcase.proto. Please use 'syntax = "proto2"
;' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 62%] Generating t/repeated/repeated_testcase.pb.cc, t/repeated/repeated_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: repeated_testcase.proto. Please use 'syntax = "proto
2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[ 63%] Generating t/repeated_packed_fixed32/repeated_packed_fixed32_testcase.pb.cc, t/repeated_packed_fixed32/repeated_packed_fixed32_testcase.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: repeated_packed_fixed32_testcase.proto. Please use '
syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
Scanning dependencies of target writer_tests
[ 64%] Building CXX object test/CMakeFiles/writer_tests.dir/writer_tests.cpp.o
...
```