### PR TITLE
Avoid out of bounds array subscript

### DIFF
--- a/include/protozero/varint.hpp
+++ b/include/protozero/varint.hpp
@@ -118,7 +118,7 @@ inline void skip_varint(const char** data, const char* end) {
         ++p;
     }
 
-    if (p >= begin + max_varint_length) {
+    if (p - begin >= max_varint_length) {
         throw varint_too_long_exception{};
     }
 


### PR DESCRIPTION
It seems gcc 9 has learnt some new tricks and is reporting an out of bounds array subscript error in the unit tests:

```
cd /builddir/build/BUILD/protozero-1.6.4/build/test/unit && /usr/lib64/ccache/c++   -I/builddir/build/BUILD/protozero-1.6.4/include -I/builddir/build/BUILD/protozero-1.6.4/test/include -isystem /builddir/build/BUILD/protozero-1.6.4/test/catch  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection   -std=c++11 -Wall -Wextra -pedantic -Wsign-compare -Wunused-parameter -Wno-float-equal -Wno-covered-switch-default -Werror -o CMakeFiles/unit_tests.dir/test_varint.cpp.o -c /builddir/build/BUILD/protozero-1.6.4/test/unit/test_varint.cpp
In file included from /builddir/build/BUILD/protozero-1.6.4/include/protozero/pbf_writer.hpp:22,
                 from /builddir/build/BUILD/protozero-1.6.4/include/protozero/pbf_builder.hpp:19,
                 from /builddir/build/BUILD/protozero-1.6.4/test/include/test.hpp:15,
                 from /builddir/build/BUILD/protozero-1.6.4/test/unit/test_varint.cpp:2:
/builddir/build/BUILD/protozero-1.6.4/include/protozero/varint.hpp: In function 'void ____C_A_T_C_H____T_E_S_T____28()':
/builddir/build/BUILD/protozero-1.6.4/include/protozero/varint.hpp:121:20: error: array subscript 10 is outside array bounds of 'char [1]' [-Werror=array-bounds]
  121 |     if (p >= begin + max_varint_length) {
      |              ~~~~~~^~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/protozero-1.6.4/test/unit/test_varint.cpp:194:10: note: while referencing 'buffer'
  194 |     char buffer;
      |          ^~~~~~
At global scope:
cc1plus: error: unrecognized command line option '-Wno-covered-switch-default' [-Werror]
cc1plus: all warnings being treated as errors
make[2]: *** [test/unit/CMakeFiles/unit_tests.dir/build.make:144: test/unit/CMakeFiles/unit_tests.dir/test_varint.cpp.o] Error 1
make[2]: Leaving directory '/builddir/build/BUILD/protozero-1.6.4/build'
make[2]: *** Waiting for unfinished jobs....
make[2]: Entering directory '/builddir/build/BUILD/protozero-1.6.4/build'
```

Ignore the second error about the command line switch but the first one is because the buffer that `skip_varint` has been given is only a single byte so it doesn't like `begin + max_varint_length` which would result in a pointer outside the object which is technically not well defined I believe.

This patch just rearranges the test by computing the difference and then comparing to the limit instead of computing a theoretical maximum end and comparing the pointers.