### PR TITLE
make testing optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #-----------------------------------------------------------------------------
 
+option(BUILD_TESTING "Build the tests" ON)
 option(WERROR "Add -Werror flag to build (turns warnings into errors)" ON)
 
 if(MSVC)
@@ -71,7 +72,9 @@ if(CLANG_TIDY)
         ${CMAKE_SOURCE_DIR}/test/unit/*.cpp
         ${CMAKE_SOURCE_DIR}/tools/*.cpp
     )
-    add_dependencies(clang-tidy writer_tests)
+    if(BUILD_TESTING)
+        add_dependencies(clang-tidy writer_tests)
+    endif()
 else()
     message(STATUS "Looking for clang-tidy - not found")
     message(STATUS "  Build target 'clang-tidy' will not be available.")
@@ -140,7 +143,8 @@ add_subdirectory(doc)
 
 add_subdirectory(tools)
 
-add_subdirectory(test)
-
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
It is desirable to be able to compile the project without executing any tests in certain circumstances, such as when cross compiling to a different target, in which case it is actually not possible to execute the tests on the build host.

This adds the `BUILD_TESTING` option to completely turn off testing.