### PR TITLE
Fixes float and double byteswap undefined behavior

### DIFF
--- a/include/protozero/byteswap.hpp
+++ b/include/protozero/byteswap.hpp
@@ -19,6 +19,7 @@ documentation.
 #include "config.hpp"
 
 #include <cstdint>
+#include <cstring>
 
 namespace protozero {
 namespace detail {
@@ -75,14 +76,22 @@ inline void byteswap_inplace(int64_t* ptr) noexcept {
 
 /// byteswap the data pointed to by ptr in-place.
 inline void byteswap_inplace(float* ptr) noexcept {
-    auto* bptr = reinterpret_cast<uint32_t*>(ptr);
-    *bptr = detail::byteswap_impl(*bptr);
+    static_assert(sizeof(float) == 4, "Expecting four byte float");
+
+    uint32_t tmp;
+    memcpy(&tmp, ptr, 4);
+    tmp = detail::byteswap_impl(tmp); // uint32 overload
+    memcpy(ptr, &tmp, 4);
 }
 
 /// byteswap the data pointed to by ptr in-place.
 inline void byteswap_inplace(double* ptr) noexcept {
-    auto* bptr = reinterpret_cast<uint64_t*>(ptr);
-    *bptr = detail::byteswap_impl(*bptr);
+    static_assert(sizeof(double) == 8, "Expecting eight byte double");
+
+    uint64_t tmp;
+    memcpy(&tmp, ptr, 8);
+    tmp = detail::byteswap_impl(tmp); // uint64 overload
+    memcpy(ptr, &tmp, 8);
 }
 
 namespace detail {


### PR DESCRIPTION
Hey there @joto :wave: 

I just had a look at the protozero code base to understand how you do the protobuf encoding, and came across this issue.

I think we had a similar conversation in the past already some five+ years ago in https://github.com/mapbox/protozero/pull/65 

and this time it's only affecting the float and double byteswap paths.

There's probably a smart paragraph in the C++ standard someone could pull up why exactly this is undefined behavior and how the strict aliasing rules work, but to be honest I'm out of the scene for too long to know details.

There's a summary in https://en.cppreference.com/w/cpp/language/reinterpret_cast where there's even an example at the bottom for what we do here with float and double pointers. The int pointer functions are fine because they are signed counterparts to their unsigned byteswap implementations, it's just the float and double pointer access which is undefined behavior.

The fix compiles the memcpy away into a native `bswap` instruction, while getting rid of the undefined behavior.

https://godbolt.org/z/MEdcn6EbP