### PR TITLE
Improve compatibility with various STL flavors

### DIFF
--- a/include/protozero/buffer_string.hpp
+++ b/include/protozero/buffer_string.hpp
@@ -57,8 +57,8 @@ struct buffer_customization<std::string> {
         protozero_assert(from <= buffer->size());
         protozero_assert(to <= buffer->size());
         protozero_assert(from <= to);
-        buffer->erase(std::advance(buffer->begin(), from),
-                      std::advance(buffer->begin(), to));
+        buffer->erase(buffer->begin() + from,
+                      buffer->begin() + to);
     }
 
     static char* at_pos(std::string* buffer, std::size_t pos) {

--- a/include/protozero/buffer_string.hpp
+++ b/include/protozero/buffer_string.hpp
@@ -57,8 +57,8 @@ struct buffer_customization<std::string> {
         protozero_assert(from <= buffer->size());
         protozero_assert(to <= buffer->size());
         protozero_assert(from <= to);
-        buffer->erase(std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(from)),
-                      std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(to)));
+        buffer->erase(std::advance(buffer->begin(), from),
+                      std::advance(buffer->begin(), to));
     }
 
     static char* at_pos(std::string* buffer, std::size_t pos) {


### PR DESCRIPTION
In our STL std::string::iterator is not a class but rather a raw pointer.
Suggested approach works as std::advance [accepts](https://en.cppreference.com/w/cpp/iterator/advance) Distance type as a template parameter.