### PR TITLE
Change license formatting to get recognized by license scanning tools

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,17 @@
-protozero copyright (c) Mapbox.
+Copyright (C) 2022, Mapbox.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in
-      the documentation and/or other materials provided with the
-      distribution.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,


### PR DESCRIPTION
Compare how GitHub recognizes the license before and after this change.

Before: 

<img width="318" alt="image"  src="https://user-images.githubusercontent.com/1527880/181102908-68f02021-7ef4-4f2e-97d6-fcda7a83ff1f.png">

After:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/1527880/181103043-c51d6e64-b832-4117-afba-6835aa3eafa4.png">

