### PR TITLE
Github action: Remove buster build, build variants on bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
           - "ubuntu:20.04"        # gcc  9.3.0, clang 10.0.0, cmake 3.16.3
           - "ubuntu:22.04"        # gcc 12.2.0, clang 15.0.7, cmake 3.24.2
           - "ubuntu:24.04"        # gcc 14.2.0, clang 18.1.3, cmake 3.28.3
-          - "debian:buster"       # gcc  8.3.0, clang  7.0.1, cmake 3.13.4
           - "debian:bullseye"     # gcc 10.2.1, clang 11.0.1, cmake 3.18.4
           - "debian:bookworm"     # gcc 12.2.0, clang 15.0.6, cmake 3.25.1
           - "debian:testing"
@@ -25,31 +24,21 @@ jobs:
         cpp_compiler: [g++]
         cpp_version: [14]
         include:
-          - image: "debian:bullseye"
+          - image: "debian:bookworm"
+            c_compiler: clang
+            cpp_compiler: clang++
+          - image: "debian:bookworm"
             cpp_version: 17
-          - image: "debian:bullseye"
+          - image: "debian:bookworm"
             cpp_version: 20
-          - image: "debian:bullseye"
-            c_compiler: clang
-            cpp_compiler: clang++
-            cpp_version: 14
-          - image: "debian:bullseye"
+          - image: "debian:bookworm"
             c_compiler: clang
             cpp_compiler: clang++
             cpp_version: 17
-          - image: "debian:bullseye"
+          - image: "debian:bookworm"
             c_compiler: clang
             cpp_compiler: clang++
             cpp_version: 20
-          - image: "debian:bullseye"
-            build_type: Release
-          - image: "debian:bullseye"
-            c_compiler: clang
-            cpp_compiler: clang++
-          - image: "debian:bullseye"
-            c_compiler: clang
-            cpp_compiler: clang++
-            data_view: std::string_view
 # Disabled because it fails due to a bug in the protobuf library
 # See https://github.com/protocolbuffers/protobuf/issues/7224
 #          - image: "debian:bullseye"
@@ -58,8 +47,11 @@ jobs:
 #            CXXFLAGS: "-fsanitize=address,undefined,integer -fno-sanitize-recover=all -fno-omit-frame-pointer"
 #            LDFLAGS: "-fsanitize=address,undefined,integer"
           - image: "debian:bookworm"
+            build_type: Release
+          - image: "debian:bookworm"
             c_compiler: clang
             cpp_compiler: clang++
+            data_view: std::string_view
           - image: "debian:testing"
             c_compiler: clang
             cpp_compiler: clang++
@@ -95,10 +87,6 @@ jobs:
             libprotobuf-dev \
             make \
             protobuf-compiler
-      - name: Install compiler
-        shell: bash
-        if: matrix.cpp_compiler == 'clang++-14'
-        run: apt-get install -y --no-install-suggests --no-install-recommends clang-14
       - name: Prepare container (dnf)
         shell: bash
         if: startsWith(matrix.image, 'fedora:')
@@ -141,7 +129,7 @@ jobs:
           - macos-15
         build_type: [Debug]
         include:
-          - os: macos-14
+          - os: macos-15
             build_type: Release
     env:
       CC: clang
@@ -170,8 +158,6 @@ jobs:
             protobuf-c:x64-windows
         shell: bash
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: ./.github/actions/cmake-windows
       - uses: ./.github/actions/build-windows
       - uses: ./.github/actions/ctest-windows


### PR DESCRIPTION
(instead of on bullseye)

Also a fix: We don't need submodules