### PR TITLE
Remove unused PROTOZERO_DATA_VIEW setting in CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,6 @@ endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
-set(PROTOZERO_DATA_VIEW "" CACHE STRING "Type used for protozero::data_view")
-if(NOT PROTOZERO_DATA_VIEW STREQUAL "")
-    add_definitions(-DPROTOZERO_DATA_VIEW=${PROTOZERO_DATA_VIEW})
-endif()
-
-
 #-----------------------------------------------------------------------------
 #
 #  Find dependencies


### PR DESCRIPTION
Probably a left-over from earlier times.

Fixes #129