### PR TITLE
Test with std::stringview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           - image: "debian:bookworm"
             c_compiler: clang
             cpp_compiler: clang++
+            cpp_version: 17
             data_view: std::string_view
           - image: "debian:testing"
             c_compiler: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
+set(PROTOZERO_DATA_VIEW "" CACHE STRING "Type used for protozero::data_view")
+if(NOT PROTOZERO_DATA_VIEW STREQUAL "")
+    add_definitions(-DPROTOZERO_DATA_VIEW=${PROTOZERO_DATA_VIEW})
+endif()
+
+
 #-----------------------------------------------------------------------------
 #
 #  Find dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,13 @@ endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
+# Used for testing
 set(PROTOZERO_DATA_VIEW "" CACHE STRING "Type used for protozero::data_view")
 if(NOT PROTOZERO_DATA_VIEW STREQUAL "")
-    add_definitions(-DPROTOZERO_DATA_VIEW=${PROTOZERO_DATA_VIEW})
+    message(STATUS "Using ${PROTOZERO_DATA_VIEW} as data_view")
+    add_definitions(-DPROTOZERO_USE_VIEW=${PROTOZERO_DATA_VIEW})
+else()
+    message(STATUS "Using built-in data_view")
 endif()
 
 

--- a/test/unit/test_data_view.cpp
+++ b/test/unit/test_data_view.cpp
@@ -53,7 +53,9 @@ TEST_CASE("convert data_view to std::string") {
     const std::string s = std::string(view);
     REQUIRE(s == "foobar");
     REQUIRE(std::string(view) == "foobar");
+#ifndef PROTOZERO_USE_VIEW
     REQUIRE(view.to_string() == "foobar");
+#endif
 }
 
 #ifndef PROTOZERO_USE_VIEW
@@ -69,14 +71,14 @@ TEST_CASE("swapping data_view") {
     protozero::data_view view1{"foo"};
     protozero::data_view view2{"bar"};
 
-    REQUIRE(view1.to_string() == "foo");
-    REQUIRE(view2.to_string() == "bar");
+    REQUIRE(std::string(view1) == "foo");
+    REQUIRE(std::string(view2) == "bar");
 
     using std::swap;
     swap(view1, view2);
 
-    REQUIRE(view2.to_string() == "foo");
-    REQUIRE(view1.to_string() == "bar");
+    REQUIRE(std::string(view2) == "foo");
+    REQUIRE(std::string(view1) == "bar");
 }
 
 TEST_CASE("comparing data_views") {


### PR DESCRIPTION
The recent change to remove the "unused" PROTOZERO_DATA_VIEW setting was premature. It was intended for testing a version of Protozero using std::string_view instead of the built-in data_view class. The test was broken though, because it set the macro PROTOZERO_DATA_VIEW instead of PROTOZERO_USE_VIEW.

This PR reverts the recent change and then fixes the test.