### PR TITLE
Github action: Remove deprecated windows-2019 build, add windows-2025

### DIFF
--- a/.github/actions/install-ubuntu/action.yml
+++ b/.github/actions/install-ubuntu/action.yml
@@ -7,6 +7,8 @@ runs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -yq \
+            doxygen \
+            graphviz \
             libprotobuf-dev \
             protobuf-compiler
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       CXX: clang++
       BUILD_TYPE: ${{ matrix.build_type }}
     steps:
-      - run: brew install protobuf
+      - run: brew install doxygen graphviz protobuf
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cmake
       - uses: ./.github/actions/build
@@ -149,8 +149,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
     steps:
       - run: |
           vcpkg install \

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,7 +11,7 @@ message(STATUS "Configuring documentation")
 message(STATUS "Looking for doxygen")
 find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
+if(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
     message(STATUS "Looking for doxygen - found")
     configure_file(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 


### PR DESCRIPTION
Also install Doxygen and graphviz on Ubuntu and macOS systems to test documentation builds there.