### PR TITLE
fix: add_bool now calls through buffer_customization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Fixed
-
+- `add_bool` now appends data through `buffer_customization<TBuffer>::push_back`.
 
 ## [1.8.1] - 2025-07-15
 

--- a/include/protozero/basic_pbf_writer.hpp
+++ b/include/protozero/basic_pbf_writer.hpp
@@ -391,7 +391,7 @@ public:
         add_field(tag, pbf_wire_type::varint);
         protozero_assert(m_pos == 0 && "you can't add fields to a parent basic_pbf_writer if there is an existing basic_pbf_writer for a submessage");
         protozero_assert(m_data);
-        m_data->push_back(static_cast<char>(value));
+        buffer_customization<TBuffer>::push_back(m_data, static_cast<char>(value));
     }
 
     /**


### PR DESCRIPTION
As described in #139 I cannot use a buffer of a non-char element type (e.g. `std::vector<std::byte>`).
By calling through the existing `buffer_customization<TBuffer>::push_back` function, this use-case should be supported. 

fixes #139.
