### PR TITLE
Check return codes of ParseFromArray calls in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
     env:
       CC: clang
       CXX: clang++
+      CXXFLAGS: -Wno-nullability-extension
       BUILD_TYPE: ${{ matrix.build_type }}
     steps:
       - run: brew install doxygen graphviz protobuf

--- a/test/t/bool/writer_test_cases.cpp
+++ b/test/t/bool/writer_test_cases.cpp
@@ -16,7 +16,7 @@ TEMPLATE_TEST_CASE("write bool field and check with libprotobuf", "",
     SECTION("false") {
         pw.add_bool(1, false);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE_FALSE(msg.b());
     }
@@ -24,7 +24,7 @@ TEMPLATE_TEST_CASE("write bool field and check with libprotobuf", "",
     SECTION("true") {
         pw.add_bool(1, true);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.b());
     }

--- a/test/t/bytes/writer_test_cases.cpp
+++ b/test/t/bytes/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write bytes field and check with libprotobuf", "",
     SECTION("empty") {
         pw.add_string(1, "");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s().empty());
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write bytes field and check with libprotobuf", "",
     SECTION("one") {
         pw.add_string(1, "x");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s() == "x");
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write bytes field and check with libprotobuf", "",
     SECTION("string") {
         pw.add_string(1, "foobar");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s() == "foobar");
     }
@@ -43,7 +43,7 @@ TEMPLATE_TEST_CASE("write bytes field and check with libprotobuf", "",
 
         pw.add_string(1, data);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s().size() == 3);
         REQUIRE(msg.s()[1] == static_cast<char>(2));

--- a/test/t/double/writer_test_cases.cpp
+++ b/test/t/double/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write double field and check with libprotobuf", "",
     SECTION("zero") {
         pw.add_double(1, 0.0);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.x() == Approx(0.0));
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write double field and check with libprotobuf", "",
     SECTION("positive") {
         pw.add_double(1, 4.893);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.x() == Approx(4.893));
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write double field and check with libprotobuf", "",
     SECTION("negative") {
         pw.add_double(1, -9232.33);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.x() == Approx(-9232.33));
     }

--- a/test/t/enum/writer_test_cases.cpp
+++ b/test/t/enum/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write enum field and check with libprotobuf", "",
     SECTION("zero") {
         pw.add_enum(1, 0L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.color() == TestEnum::Color::BLACK);
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write enum field and check with libprotobuf", "",
     SECTION("positive") {
         pw.add_enum(1, 3L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.color() == TestEnum::Color::BLUE);
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write enum field and check with libprotobuf", "",
     SECTION("negative") {
         pw.add_enum(1, -1L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.color() == TestEnum::Color::NEG);
     }
@@ -38,7 +38,7 @@ TEMPLATE_TEST_CASE("write enum field and check with libprotobuf", "",
     SECTION("max") {
         pw.add_enum(1, std::numeric_limits<int32_t>::max() - 1);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.color() == TestEnum::Color::MAX);
     }
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("write enum field and check with libprotobuf", "",
     SECTION("min") {
         pw.add_enum(1, std::numeric_limits<int32_t>::min() + 1);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.color() == TestEnum::Color::MIN);
     }

--- a/test/t/fixed32/writer_test_cases.cpp
+++ b/test/t/fixed32/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write fixed32 field and check with libprotobuf", "",
     SECTION("zero") {
         pw.add_fixed32(1, 0);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == 0);
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write fixed32 field and check with libprotobuf", "",
     SECTION("max") {
         pw.add_fixed32(1, std::numeric_limits<uint32_t>::max());
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == std::numeric_limits<uint32_t>::max());
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write fixed32 field and check with libprotobuf", "",
     SECTION("min") {
         pw.add_fixed32(1, std::numeric_limits<uint32_t>::min());
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == std::numeric_limits<uint32_t>::min());
     }

--- a/test/t/int32/writer_test_cases.cpp
+++ b/test/t/int32/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write int32 field and check with libprotobuf", "",
     SECTION("zero") {
         pw.add_int32(1, 0L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == 0L);
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write int32 field and check with libprotobuf", "",
     SECTION("positive") {
         pw.add_int32(1, 1L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == 1L);
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write int32 field and check with libprotobuf", "",
     SECTION("negative") {
         pw.add_int32(1, -1L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == -1L);
     }
@@ -38,7 +38,7 @@ TEMPLATE_TEST_CASE("write int32 field and check with libprotobuf", "",
     SECTION("max") {
         pw.add_int32(1, std::numeric_limits<int32_t>::max());
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == std::numeric_limits<int32_t>::max());
     }
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("write int32 field and check with libprotobuf", "",
     SECTION("min") {
         pw.add_int32(1, std::numeric_limits<int32_t>::min());
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i() == std::numeric_limits<int32_t>::min());
     }

--- a/test/t/message/writer_test_cases.cpp
+++ b/test/t/message/writer_test_cases.cpp
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE("write message field and check with libprotobuf", "",
     }
 
     TestMessage::Test msg;
-    msg.ParseFromArray(buffer.data(), buffer.size());
+    REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
     REQUIRE(msg.submessage().s() == "foobar");
 
 }

--- a/test/t/nested/writer_test_cases.cpp
+++ b/test/t/nested/writer_test_cases.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("write nested message fields and check with libprotobuf", "",
     pw.add_int32(2, 77);
 
     TestNested::Test msg;
-    msg.ParseFromArray(buffer.data(), buffer.size());
+    REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
     REQUIRE(msg.i() == 77);
     REQUIRE(msg.sub().i() == 88);

--- a/test/t/repeated/writer_test_cases.cpp
+++ b/test/t/repeated/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write repeated fields and check with libprotobuf", "",
     SECTION("one") {
         pw.add_int32(1, 0L);
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i().size() == 1);
         REQUIRE(msg.i(0) == 0L);
@@ -27,7 +27,7 @@ TEMPLATE_TEST_CASE("write repeated fields and check with libprotobuf", "",
         pw.add_int32(1, std::numeric_limits<int32_t>::max());
         pw.add_int32(1, std::numeric_limits<int32_t>::min());
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i().size() == 5);
         REQUIRE(msg.i(0) == 0L);

--- a/test/t/repeated_packed_fixed32/writer_test_cases.cpp
+++ b/test/t/repeated_packed_fixed32/writer_test_cases.cpp
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE("write repeated packed fixed32 field and check with libprotob
         const std::array<uint32_t, 1> data = {{ 17UL }};
         pw.add_packed_fixed32(1, std::begin(data), std::end(data));
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i().size() == 1);
         REQUIRE(msg.i(0) == 17UL);
@@ -33,7 +33,7 @@ TEMPLATE_TEST_CASE("write repeated packed fixed32 field and check with libprotob
         const std::array<uint32_t, 4> data = {{ 17UL, 0UL, 1UL, std::numeric_limits<uint32_t>::max() }};
         pw.add_packed_fixed32(1, std::begin(data), std::end(data));
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.i().size() == 4);
         REQUIRE(msg.i(0) == 17UL);
@@ -67,7 +67,7 @@ TEMPLATE_TEST_CASE("write from different types of iterators and check with libpr
         pw.template add_packed_fixed<uint32_t>(1, it, eod);
     }
 
-    msg.ParseFromArray(buffer.data(), buffer.size());
+    REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
     REQUIRE(msg.i().size() == 5);
     REQUIRE(msg.i(0) ==  1);

--- a/test/t/string/writer_test_cases.cpp
+++ b/test/t/string/writer_test_cases.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("write string field and check with libprotobuf", "",
     SECTION("empty") {
         pw.add_string(1, "");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s().empty());
     }
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE("write string field and check with libprotobuf", "",
     SECTION("one") {
         pw.add_string(1, "x");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s() == "x");
     }
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("write string field and check with libprotobuf", "",
     SECTION("string") {
         pw.add_string(1, "foobar");
 
-        msg.ParseFromArray(buffer.data(), buffer.size());
+        REQUIRE(msg.ParseFromArray(buffer.data(), buffer.size()));
 
         REQUIRE(msg.s() == "foobar");
     }


### PR DESCRIPTION
Some versions of the protobuf library mark the as [[nodiscard]].