### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,6 +2,9 @@ name: clang-tidy
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mapbox/protozero/security/code-scanning/6](https://github.com/mapbox/protozero/security/code-scanning/6)

Add an explicit `permissions` block at the workflow root in `.github/workflows/clang-tidy.yml`, directly under the `on` trigger (before `jobs`). For this workflow, the minimal required scope is `contents: read`, which is sufficient for checking out source and does not grant unnecessary write privileges. This preserves current functionality while enforcing least privilege and preventing future drift if repository/org defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
