### PR TITLE
Some CMake config improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      CXXFLAGS: -Wno-nullability-extension
       BUILD_TYPE: ${{ matrix.build_type }}
     steps:
       - run: brew install doxygen graphviz protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 #
 #-----------------------------------------------------------------------------
 message(STATUS "Looking for clang-tidy")
-find_program(CLANG_TIDY NAMES clang-tidy-20 clang-tidy-19 clang-tidy-18 clang-tidy-17 clang-tidy-16 clang-tidy-15)
+find_program(CLANG_TIDY NAMES clang-tidy clang-tidy-20 clang-tidy-19 clang-tidy-18 clang-tidy-17 clang-tidy-16 clang-tidy-15)
 
 if(CLANG_TIDY AND PROTOBUF_FOUND)
     message(STATUS "Looking for clang-tidy - found ${CLANG_TIDY}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,11 @@ if(PROTOBUF_FOUND)
         endif()
     endforeach()
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Google Protobuf library adds non-standard _Nonnull to Abseil macros
+        set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-nullability-extension")
+    endif()
+
     add_executable(writer_tests writer_tests.cpp ${SOURCES} ${PROTO_SRCS} ${PROTO_HDRS})
 
     target_compile_features(writer_tests PUBLIC cxx_std_14)


### PR DESCRIPTION
Look for clang-tidy also under the name without version. Disable a warning in Clang.