### PR TITLE
Speed up packed varint decoding by validating the region up front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `decode_varint_unchecked()` and `skip_varint_unchecked()` low-level helpers in `varint.hpp`.
+
 ### Changed
+
+- The packed varint iterators (`const_varint_iterator`, `const_svarint_iterator`) now only store a single pointer instead of two, which speeds up decoding by 30-150%, depending on varint length. The  constructor now validates once that the byte range ends on a varint boundary and stores only the data pointer. A packed field whose last byte still has its continuation bit set (i.e. a truncated trailing varint, which is illegal) now throws `end_of_buffer_exception` when the iterator range is created (from `get_packed_*()`) rather than later during iteration.
 
 ### Fixed
 

--- a/include/protozero/iterators.hpp
+++ b/include/protozero/iterators.hpp
@@ -17,6 +17,7 @@ documentation.
  */
 
 #include "config.hpp"
+#include "exception.hpp"
 #include "varint.hpp"
 
 #if PROTOZERO_BYTE_ORDER != PROTOZERO_LITTLE_ENDIAN
@@ -293,9 +294,6 @@ protected:
     /// Pointer to current iterator position
     const char* m_data = nullptr; // NOLINT(misc-non-private-member-variables-in-classes, cppcoreguidelines-non-private-member-variables-in-classes,-warnings-as-errors)
 
-    /// Pointer to end iterator position
-    const char* m_end = nullptr; // NOLINT(misc-non-private-member-variables-in-classes, cppcoreguidelines-non-private-member-variables-in-classes,-warnings-as-errors)
-
 public:
 
     /// @cond usual iterator functions not documented
@@ -322,9 +320,14 @@ public:
 
     const_varint_iterator() noexcept = default;
 
-    const_varint_iterator(const char* data, const char* end) noexcept :
-        m_data{data},
-        m_end{end} {
+    const_varint_iterator(const char* data, const char* end) :
+        m_data{data} {
+        // The decoders used by this iterator run without an explicit end
+        // pointer. This is only safe if the region ends exactly on a varint
+        // boundary, i.e. the last byte does not have its continuation bit set.
+        if (data != end && (static_cast<unsigned char>(*(end - 1)) & 0x80U) != 0) {
+            throw end_of_buffer_exception{};
+        }
     }
 
     const_varint_iterator(const const_varint_iterator&) noexcept = default;
@@ -338,12 +341,12 @@ public:
     value_type operator*() const {
         protozero_assert(m_data);
         const char* d = m_data; // will be thrown away
-        return static_cast<value_type>(decode_varint(&d, m_end));
+        return static_cast<value_type>(decode_varint_unchecked(&d));
     }
 
     const_varint_iterator& operator++() {
         protozero_assert(m_data);
-        skip_varint(&m_data, m_end);
+        skip_varint_unchecked(&m_data);
         return *this;
     }
 
@@ -355,7 +358,7 @@ public:
     }
 
     bool operator==(const const_varint_iterator& rhs) const noexcept {
-        return m_data == rhs.m_data && m_end == rhs.m_end;
+        return m_data == rhs.m_data;
     }
 
     bool operator!=(const const_varint_iterator& rhs) const noexcept {
@@ -387,7 +390,7 @@ public:
         const_varint_iterator<T>{} {
     }
 
-    const_svarint_iterator(const char* data, const char* end) noexcept :
+    const_svarint_iterator(const char* data, const char* end) :
         const_varint_iterator<T>{data, end} {
     }
 
@@ -402,12 +405,12 @@ public:
     value_type operator*() const {
         protozero_assert(this->m_data);
         const char* d = this->m_data; // will be thrown away
-        return static_cast<value_type>(decode_zigzag64(decode_varint(&d, this->m_end)));
+        return static_cast<value_type>(decode_zigzag64(decode_varint_unchecked(&d)));
     }
 
     const_svarint_iterator& operator++() {
         protozero_assert(this->m_data);
-        skip_varint(&this->m_data, this->m_end);
+        skip_varint_unchecked(&this->m_data);
         return *this;
     }
 

--- a/include/protozero/varint.hpp
+++ b/include/protozero/varint.hpp
@@ -133,6 +133,75 @@ inline void skip_varint(const char** data, const char* end) {
 }
 
 /**
+ * Decode a 64 bit varint *without* checking against an end pointer.
+ *
+ * This is only safe to call when it is guaranteed that the byte sequence
+ * contains a complete varint, ie. that the last byte of the region being
+ * iterated over has its most significant (continuation) bit not set. Under
+ * that invariant the scan always terminates at-or-before that final byte, so
+ * no end pointer is needed. This is used by the packed varint iterators which
+ * validate this invariant once when they are created. Overlong varints (longer
+ * than the maximum length that fits into a 64 bit integer) are still detected.
+ *
+ * Strong exception guarantee: if there is an exception the data pointer will
+ * not be changed.
+ *
+ * @param[in,out] data Pointer to pointer to the input data. After the function
+ *        returns this will point to the next data to be read.
+ * @returns The decoded integer
+ * @throws varint_too_long_exception if the varint is longer then the maximum
+ *         length that would fit in a 64 bit int.
+ */
+inline uint64_t decode_varint_unchecked(const char** data) {
+    const auto* p = reinterpret_cast<const int8_t*>(*data);
+    uint64_t val = 0;
+    int64_t b = 0;
+
+    do {
+        b = *p++; val  = ((static_cast<uint64_t>(b) & 0x7fU)       ); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) <<  7U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 14U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 21U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 28U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 35U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 42U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 49U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x7fU) << 56U); if (b >= 0) { break; }
+        b = *p++; val |= ((static_cast<uint64_t>(b) & 0x01U) << 63U); if (b >= 0) { break; }
+        throw varint_too_long_exception{};
+    } while (false);
+
+    *data = reinterpret_cast<const char*>(p);
+    return val;
+}
+
+/**
+ * Skip over a varint *without* checking against an end pointer.
+ *
+ * See decode_varint_unchecked() for the invariant that makes this safe.
+ *
+ * Strong exception guarantee: if there is an exception the data pointer will
+ * not be changed.
+ *
+ * @param[in,out] data Pointer to pointer to the input data. After the function
+ *        returns this will point to the next data to be read.
+ * @throws varint_too_long_exception if the varint is longer then the maximum
+ *         length that would fit in a 64 bit int.
+ */
+inline void skip_varint_unchecked(const char** data) {
+    const auto* p = reinterpret_cast<const int8_t*>(*data);
+
+    for (int8_t i = 0; i < max_varint_length; ++i) {
+        if (*p++ >= 0) {
+            *data = reinterpret_cast<const char*>(p);
+            return;
+        }
+    }
+
+    throw varint_too_long_exception{};
+}
+
+/**
  * Varint encode a 64 bit integer.
  *
  * @tparam T An output iterator type.

--- a/test/unit/test_iterators.cpp
+++ b/test/unit/test_iterators.cpp
@@ -16,3 +16,27 @@ TEST_CASE("default constructed varint_iterators are equal") {
     REQUIRE(r.begin() == r.end());
 }
 
+TEST_CASE("get_packed varint reads a well-formed region") {
+    // field 1, wire type 2 (length-delimited); length 2; varints 5 and 1.
+    const std::string buffer{"\x0a\x02\x05\x01", 4};
+    protozero::pbf_reader item{buffer};
+
+    REQUIRE(item.next());
+    const auto range = item.get_packed_uint64();
+    auto it = range.begin();
+    REQUIRE(*it++ == 5);
+    REQUIRE(*it++ == 1);
+    REQUIRE(it == range.end());
+}
+
+TEST_CASE("get_packed varint rejects a truncated trailing varint") {
+    // field 1, wire type 2; length 1; single byte 0x80 with the continuation
+    // bit set and no terminating byte: the region does not end on a varint
+    // boundary, so this must be rejected when the range is created.
+    const std::string buffer{"\x0a\x01\x80", 3};
+    protozero::pbf_reader item{buffer};
+
+    REQUIRE(item.next());
+    REQUIRE_THROWS_AS(item.get_packed_uint64(), protozero::end_of_buffer_exception);
+}
+

--- a/test/unit/test_varint.cpp
+++ b/test/unit/test_varint.cpp
@@ -1,6 +1,32 @@
 
 #include <test.hpp>
 
+namespace {
+
+struct checked_varint_decoder {
+    static uint64_t decode(const char** data, const char* end) {
+        return protozero::decode_varint(data, end);
+    }
+
+    static void skip(const char** data, const char* end) {
+        protozero::skip_varint(data, end);
+    }
+};
+
+struct unchecked_varint_decoder {
+    static uint64_t decode(const char** data, const char* end) {
+        (void)end;
+        return protozero::decode_varint_unchecked(data);
+    }
+
+    static void skip(const char** data, const char* end) {
+        (void)end;
+        protozero::skip_varint_unchecked(data);
+    }
+};
+
+} // namespace
+
 TEST_CASE("max varint length") {
     REQUIRE(protozero::max_varint_length == 10);
 }
@@ -245,6 +271,124 @@ TEST_CASE("call decode_varint_unchecked with every possible value of terminal va
         const char* b = buffer;
         REQUIRE(protozero::decode_varint_unchecked(&b) == i);
         REQUIRE(b == buffer + 1);
+    }
+}
+
+template <typename Decoder>
+void test_decode_various_lengths() {
+    const std::vector<uint64_t> values{
+        0,
+        127,
+        128,
+        16383,
+        16384,
+        2097151,
+        2097152,
+        0xffffffffULL,
+        0xffffffffffffffffULL,
+        1ULL << 40U,
+    };
+
+    for (const auto value : values) {
+        std::string buffer;
+        protozero::add_varint_to_buffer(&buffer, value);
+        const char* b = buffer.data();
+        const char* const end = buffer.data() + buffer.size();
+        REQUIRE(Decoder::decode(&b, end) == value);
+        REQUIRE(b == end);
+    }
+}
+
+TEST_CASE("decode_varint with varints of various lengths") {
+    SECTION("checked") {
+        test_decode_various_lengths<checked_varint_decoder>();
+    }
+
+    SECTION("unchecked") {
+        test_decode_various_lengths<unchecked_varint_decoder>();
+    }
+}
+
+template <typename Decoder>
+void test_skip_various_lengths() {
+    const std::vector<uint64_t> values{
+        0,
+        127,
+        128,
+        16383,
+        16384,
+        2097151,
+        2097152,
+        0xffffffffULL,
+        0xffffffffffffffffULL,
+        1ULL << 40U,
+    };
+
+    for (const auto value : values) {
+        std::string buffer;
+        protozero::add_varint_to_buffer(&buffer, value);
+        const char* b = buffer.data();
+        const char* const end = buffer.data() + buffer.size();
+        Decoder::skip(&b, end);
+        REQUIRE(b == end);
+    }
+}
+
+TEST_CASE("skip_varint with varints of various lengths") {
+    SECTION("checked") {
+        test_skip_various_lengths<checked_varint_decoder>();
+    }
+
+    SECTION("unchecked") {
+        test_skip_various_lengths<unchecked_varint_decoder>();
+    }
+}
+
+template <typename Decoder>
+void test_decode_multiple_varints_in_sequence() {
+    std::string buffer;
+    protozero::add_varint_to_buffer(&buffer, 5);
+    protozero::add_varint_to_buffer(&buffer, 1);
+    protozero::add_varint_to_buffer(&buffer, 300);
+
+    const char* b = buffer.data();
+    const char* const end = buffer.data() + buffer.size();
+    REQUIRE(Decoder::decode(&b, end) == 5);
+    REQUIRE(Decoder::decode(&b, end) == 1);
+    REQUIRE(Decoder::decode(&b, end) == 300);
+    REQUIRE(b == end);
+}
+
+TEST_CASE("decode multiple varints in sequence") {
+    SECTION("checked") {
+        test_decode_multiple_varints_in_sequence<checked_varint_decoder>();
+    }
+
+    SECTION("unchecked") {
+        test_decode_multiple_varints_in_sequence<unchecked_varint_decoder>();
+    }
+}
+
+template <typename Decoder>
+void test_overlong_varint_throws() {
+    std::string buffer(10, static_cast<char>(0xffU));
+    const char* b = buffer.data();
+    const char* const end = buffer.data() + buffer.size();
+    REQUIRE_THROWS_AS(Decoder::decode(&b, end), protozero::varint_too_long_exception);
+    REQUIRE(b == buffer.data());
+
+    b = buffer.data();
+    REQUIRE_THROWS_AS([&]() { Decoder::skip(&b, end); }(), protozero::varint_too_long_exception);
+    REQUIRE(b == buffer.data());
+}
+
+TEST_CASE("overlong varint throws varint_too_long_exception") {
+    SECTION("checked") {
+        test_overlong_varint_throws<checked_varint_decoder>();
+    }
+
+    SECTION("unchecked") {
+        test_overlong_varint_throws<unchecked_varint_decoder>();
     }
 }
 

--- a/test/unit/test_varint.cpp
+++ b/test/unit/test_varint.cpp
@@ -205,6 +205,16 @@ TEST_CASE("call skip_varint with every possible value for single byte in buffer"
     }
 }
 
+TEST_CASE("call skip_varint_unchecked with every possible value of terminal varints in buffer") {
+    char buffer[1];
+    for (int i = 0; i <= 127; ++i) {
+        buffer[0] = static_cast<char>(i);
+        const char* b = buffer;
+        protozero::skip_varint_unchecked(&b);
+        REQUIRE(b == buffer + 1);
+    }
+}
+
 TEST_CASE("decode_varint with empty buffer throws") {
     const char* buffer = "";
     REQUIRE_THROWS_AS(protozero::decode_varint(&buffer, buffer), protozero::end_of_buffer_exception);
@@ -224,6 +234,17 @@ TEST_CASE("call decode_varint with every possible value for single byte in buffe
         buffer[0] = static_cast<char>(i);
         const char* b = buffer;
         REQUIRE_THROWS_AS(protozero::decode_varint(&b, buffer + 1), protozero::end_of_buffer_exception);
+    }
+}
+
+TEST_CASE("call decode_varint_unchecked with every possible value of terminal varints in buffer") {
+    char buffer[1];
+    for (unsigned int i = 0; i <= 127; ++i) {
+        REQUIRE(protozero::length_of_varint(i) == 1);
+        buffer[0] = static_cast<char>(i);
+        const char* b = buffer;
+        REQUIRE(protozero::decode_varint_unchecked(&b) == i);
+        REQUIRE(b == buffer + 1);
     }
 }
 


### PR DESCRIPTION
Decoding packed varint fields is now 30-150% faster, depending on varint length. The speedup comes from the new `decode_varint_unchecked()` / `skip_varint_unchecked()` helpers, which decode a varint without checking against an end pointer on every byte. A side effect is that our iterator size is now a single pointer, aligning it with the fixed iterators.

This is safe because a packed varint region is valid only if its last byte has the continuation bit clear, i.e. it ends exactly on a varint boundary. That guarantees a decode starting anywhere inside the region always terminates at or before the final byte, so no end pointer is needed. The packed varint iterators (`const_varint_iterator`, `const_svarint_iterator`) check this once in their constructor, and as a result no longer need to store the end pointer at all: they now hold a single pointer instead of two. That halves their size, but on its own it doesn't measurably change decoding speed (overlong varints are still detected via the byte-count limit).

Behavior change: a packed varint field whose trailing varint is truncated now throws `end_of_buffer_exception` when the iterator range is created (in `get_packed_*()`) instead of later during iteration. Arguably this doesn't matter because a truncated varint in a packed field is illegal anyway. The iterators' `(data, end)` constructor is also no longer `noexcept`.